### PR TITLE
feat: support down to node 14, support non-nodejs environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Internal method to send a request to the API. You can use it to send a custom re
 This property contains object with cookies that are set for the instance. You can use it to save and load cookies to avoid doing the consent process every time.
 
 ## Using proxy
-You can use undici dispatcher to proxy requests if using Node 18 or newer. Here's an example:
+You can use undici dispatcher to proxy requests. Here's an example:
 ```javascript
 import Lens from 'chrome-lens-ocr';
 import { ProxyAgent } from 'undici';
@@ -48,14 +48,6 @@ const lens = new Lens({
     dispatcher: new ProxyAgent('http://user:pass@example.com:8080')
 });
 ```
-If you're using versions prior to Node 18 you need to use the http proxy:
-```javascript
-import Lens from 'chrome-lens-ocr';
-import { HttpProxyAgent } from 'http-proxy-agent';
-
-const lens = new Lens({
-    agent: new HttpProxyAgent('http://user:pass@example.com:8080')
-});
 ```
 
 ## Using your cookies
@@ -99,8 +91,7 @@ Options can be empty, or contain the following (default values):
   chromeVersion: '121.0.6167.140', // Version of Chromium to "use"
   userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36', // user agent to use, major Chrome version should match the previous value
   headers: {}, // you can add headers here, they'll override the default ones
-  dispatcher: undefined, // you can use undici dispatcher to proxy requests if using node 18 or later with built-in fetch
-  agent: undefined, // you can use http agent to proxy requests if using node-fetch before node 18
+  dispatcher: undefined // you can use undici dispatcher to proxy requests
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,22 @@ Internal method to send a request to the API. You can use it to send a custom re
 This property contains object with cookies that are set for the instance. You can use it to save and load cookies to avoid doing the consent process every time.
 
 ## Using proxy
-You can use undici dispatcher to proxy requests. Here's an example:
+You can use undici dispatcher to proxy requests if using Node 18 or newer. Here's an example:
 ```javascript
 import Lens from 'chrome-lens-ocr';
 import { ProxyAgent } from 'undici';
 
 const lens = new Lens({
     dispatcher: new ProxyAgent('http://user:pass@example.com:8080')
+});
+```
+If you're using versions prior to Node 18 you need to use the http proxy:
+```javascript
+import Lens from 'chrome-lens-ocr';
+import { HttpProxyAgent } from 'http-proxy-agent';
+
+const lens = new Lens({
+    agent: new HttpProxyAgent('http://user:pass@example.com:8080')
 });
 ```
 
@@ -74,6 +83,15 @@ const lens = new Lens({
 });
 ```
 
+## Headless
+You can use this library in environments which don't support Node.js API's by importing only the core, which doesn't include the "scanBy" utility functions:
+```javascript
+import LensCore from 'chrome-lens-ocr/src/core.js'
+
+const lens = new Lens()
+lens.scanByData(new Uint8Array([41, 40, 236, 244, 151, 101, 118, 16, 37, 138, 199, 229, 2, 75, 33]), 'myImage.png', 'image/png')
+
+
 ## Options
 Options can be empty, or contain the following (default values):
 ```javascript
@@ -81,7 +99,8 @@ Options can be empty, or contain the following (default values):
   chromeVersion: '121.0.6167.140', // Version of Chromium to "use"
   userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36', // user agent to use, major Chrome version should match the previous value
   headers: {}, // you can add headers here, they'll override the default ones
-  dispatcher: undefined, // you can use undici dispatcher to proxy requests
+  dispatcher: undefined, // you can use undici dispatcher to proxy requests if using node 16 or later
+  agent: undefined, // you can use http agent to proxy requests if using node-fetch before node 16 polyfilled globally
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,15 @@ const lens = new Lens({
 });
 ```
 
-## Headless
-You can use this library in environments which don't support Node.js API's by importing only the core, which doesn't include the "scanBy" utility functions:
+## Using in other environments
+You can use this library in environments that don't support Node.js APIs by importing only the core, which doesn't include other "scanBy" utility functions:
 ```javascript
 import LensCore from 'chrome-lens-ocr/src/core.js';
 
 const lens = new LensCore();
 lens.scanByData(new Uint8Array([41, 40, 236, 244, 151, 101, 118, 16, 37, 138, 199, 229, 2, 75, 33]), 'myImage.png', 'image/png');
 ```
+But in this case, you'll need to handle resizing images to less than 1000x1000 dimensions yourself, as larger images aren't supported by Google Lens.
 
 ## Options
 Options can be empty, or contain the following (default values):

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ const lens = new Lens({
 ## Headless
 You can use this library in environments which don't support Node.js API's by importing only the core, which doesn't include the "scanBy" utility functions:
 ```javascript
-import LensCore from 'chrome-lens-ocr/src/core.js'
+import LensCore from 'chrome-lens-ocr/src/core.js';
 
-const lens = new Lens()
-lens.scanByData(new Uint8Array([41, 40, 236, 244, 151, 101, 118, 16, 37, 138, 199, 229, 2, 75, 33]), 'myImage.png', 'image/png')
-
+const lens = new LensCore();
+lens.scanByData(new Uint8Array([41, 40, 236, 244, 151, 101, 118, 16, 37, 138, 199, 229, 2, 75, 33]), 'myImage.png', 'image/png');
+```
 
 ## Options
 Options can be empty, or contain the following (default values):
@@ -99,8 +99,8 @@ Options can be empty, or contain the following (default values):
   chromeVersion: '121.0.6167.140', // Version of Chromium to "use"
   userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36', // user agent to use, major Chrome version should match the previous value
   headers: {}, // you can add headers here, they'll override the default ones
-  dispatcher: undefined, // you can use undici dispatcher to proxy requests if using node 16 or later
-  agent: undefined, // you can use http agent to proxy requests if using node-fetch before node 16 polyfilled globally
+  dispatcher: undefined, // you can use undici dispatcher to proxy requests if using node 18 or later with built-in fetch
+  agent: undefined, // you can use http agent to proxy requests if using node-fetch before node 18
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ const lens = new Lens({
     dispatcher: new ProxyAgent('http://user:pass@example.com:8080')
 });
 ```
-```
 
 ## Using your cookies
 You can use your own cookies to be authorized in Google. This is optional. Here's an example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "clipboardy": "^4.0.0",
-        "cross-fetch-ponyfill": "^1.0.3",
         "file-type": "^19.0.0",
         "image-dimensions": "^2.3.0",
         "set-cookie-parser": "^2.6.0",
-        "sharp": "^0.33.2"
+        "sharp": "^0.33.2",
+        "undici": "^5.28.3"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -24,6 +24,14 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -462,17 +470,6 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/clipboardy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
@@ -526,15 +523,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/cross-fetch-ponyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cross-fetch-ponyfill/-/cross-fetch-ponyfill-1.0.3.tgz",
-      "integrity": "sha512-uOBkDhUAGAbx/FEzNKkOfx3w57H8xReBBXoZvUnOKTI0FW0Xvrj3GrYv2iZXUqlffC1LMGfQzhmBM/ke+6eTDA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^3.3.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -548,28 +536,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -594,28 +566,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-type": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.0.0.tgz",
@@ -630,17 +580,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/get-stream": {
@@ -805,41 +744,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/npm-run-path": {
@@ -1112,18 +1016,21 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "optional": true
     },
+    "node_modules/undici": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
-      "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "chrome-lens-ocr",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chrome-lens-ocr",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "clipboardy": "^4.0.0",
+        "cross-fetch-ponyfill": "^1.0.3",
         "file-type": "^19.0.0",
         "image-dimensions": "^2.3.0",
         "set-cookie-parser": "^2.6.0",
-        "sharp": "^0.33.2",
-        "undici": "^6.6.0"
+        "sharp": "^0.33.2"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -24,14 +24,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -470,6 +462,17 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/clipboardy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
@@ -523,6 +526,15 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/cross-fetch-ponyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch-ponyfill/-/cross-fetch-ponyfill-1.0.3.tgz",
+      "integrity": "sha512-uOBkDhUAGAbx/FEzNKkOfx3w57H8xReBBXoZvUnOKTI0FW0Xvrj3GrYv2iZXUqlffC1LMGfQzhmBM/ke+6eTDA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.3.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -536,12 +548,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -566,6 +594,28 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-type": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.0.0.tgz",
@@ -580,6 +630,17 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/get-stream": {
@@ -746,6 +807,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
@@ -853,9 +949,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1016,21 +1112,18 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "optional": true
     },
-    "node_modules/undici": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.0.tgz",
-      "integrity": "sha512-p8VvLAgnx6g9pydV0GG/kciSx3ZCq5PLeEU4yefjoZCc1HSeiMxbrFzYIZlgSMrX3l0CoTJ37C6edu13acE40A==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+      "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "homepage": "https://github.com/dimdenGD/chrome-lens-ocr#readme",
   "dependencies": {
     "clipboardy": "^4.0.0",
+    "cross-fetch-ponyfill": "^1.0.3",
     "file-type": "^19.0.0",
     "image-dimensions": "^2.3.0",
     "set-cookie-parser": "^2.6.0",
-    "sharp": "^0.33.2",
-    "undici": "^6.6.0"
+    "sharp": "^0.33.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "homepage": "https://github.com/dimdenGD/chrome-lens-ocr#readme",
   "dependencies": {
     "clipboardy": "^4.0.0",
-    "cross-fetch-ponyfill": "^1.0.3",
     "file-type": "^19.0.0",
     "image-dimensions": "^2.3.0",
     "set-cookie-parser": "^2.6.0",
-    "sharp": "^0.33.2"
+    "sharp": "^0.33.2",
+    "undici": "^5.28.3"
   }
 }

--- a/sharex.js
+++ b/sharex.js
@@ -1,29 +1,29 @@
-import clipboardy from 'clipboardy'
-import Lens from './src/index.js'
-import { sleep } from './src/utils.js'
-import fs from 'fs'
-import path from 'path'
+import clipboardy from 'clipboardy';
+import Lens from './src/index.js';
+import { sleep } from './src/utils.js';
+import fs from 'fs';
+import path from 'path';
 
 try {
     // get file path from command line
-    const args = process.argv.slice(2)
-    const file = args[0]
+    const args = process.argv.slice(2);
+    const file = args[0];
 
     // get path to cookies file (should be in the same directory as this script)
-    let moduleUrl = import.meta.url
+    let moduleUrl = import.meta.url;
     if (moduleUrl.startsWith('file://')) {
-        moduleUrl = moduleUrl.slice(7)
+        moduleUrl = moduleUrl.slice(7);
     }
-    const __dirname = path.dirname(moduleUrl)
-    let pathToCookies = path.join(__dirname, 'cookies.json')
+    const __dirname = path.dirname(moduleUrl);
+    let pathToCookies = path.join(__dirname, 'cookies.json');
     if (pathToCookies.match(/^\\[A-Z]:\\/)) {
-        pathToCookies = pathToCookies.slice(1)
+        pathToCookies = pathToCookies.slice(1);
     }
 
     // read cookies from file
-    let cookies
+    let cookies;
     if (fs.existsSync(pathToCookies)) {
-        cookies = JSON.parse(fs.readFileSync(pathToCookies, 'utf8'))
+        cookies = JSON.parse(fs.readFileSync(pathToCookies, 'utf8'));
     }
 
     // create lens instance
@@ -31,18 +31,18 @@ try {
         headers: {
             cookie: cookies
         }
-    })
+    });
 
     // scan file
-    const text = await lens.scanByFile(file)
+    const text = await lens.scanByFile(file);
 
     // write cookies to file
-    fs.writeFileSync(pathToCookies, JSON.stringify(lens.cookies, null, 4))
+    fs.writeFileSync(pathToCookies, JSON.stringify(lens.cookies, null, 4));
 
     // write text to clipboard
-    clipboardy.writeSync(text.text_segments.join('\n'))
+    clipboardy.writeSync(text.text_segments.join('\n'));
 } catch (e) {
-    console.error('Error occurred:')
-    console.error(e)
-    await sleep(30000)
+    console.error('Error occurred:');
+    console.error(e);
+    await sleep(30000);
 }

--- a/sharex.js
+++ b/sharex.js
@@ -1,48 +1,48 @@
-import clipboardy from "clipboardy";
-import Lens from "./src/index.js";
-import { sleep } from "./src/utils.js";
-import fs from "fs";
-import path from "path";
+import clipboardy from 'clipboardy'
+import Lens from './src/index.js'
+import { sleep } from './src/utils.js'
+import fs from 'fs'
+import path from 'path'
 
 try {
     // get file path from command line
-    const args = process.argv.slice(2);
-    const file = args[0];
+    const args = process.argv.slice(2)
+    const file = args[0]
 
     // get path to cookies file (should be in the same directory as this script)
-    let moduleUrl = import.meta.url;
-    if(moduleUrl.startsWith('file://')) {
-        moduleUrl = moduleUrl.slice(7);
+    let moduleUrl = import.meta.url
+    if (moduleUrl.startsWith('file://')) {
+        moduleUrl = moduleUrl.slice(7)
     }
-    const __dirname = path.dirname(moduleUrl);
-    let pathToCookies = path.join(__dirname, 'cookies.json');
-    if(pathToCookies.match(/^\\[A-Z]:\\/)) {
-        pathToCookies = pathToCookies.slice(1);
+    const __dirname = path.dirname(moduleUrl)
+    let pathToCookies = path.join(__dirname, 'cookies.json')
+    if (pathToCookies.match(/^\\[A-Z]:\\/)) {
+        pathToCookies = pathToCookies.slice(1)
     }
 
     // read cookies from file
-    let cookies;
-    if(fs.existsSync(pathToCookies)) {
-        cookies = JSON.parse(fs.readFileSync(pathToCookies, 'utf8'));
+    let cookies
+    if (fs.existsSync(pathToCookies)) {
+        cookies = JSON.parse(fs.readFileSync(pathToCookies, 'utf8'))
     }
 
     // create lens instance
     const lens = new Lens({
         headers: {
-            'cookie': cookies
+            cookie: cookies
         }
-    });
+    })
 
     // scan file
-    const text = await lens.scanByFile(file);
+    const text = await lens.scanByFile(file)
 
     // write cookies to file
-    fs.writeFileSync(pathToCookies, JSON.stringify(lens.cookies, null, 4));
+    fs.writeFileSync(pathToCookies, JSON.stringify(lens.cookies, null, 4))
 
     // write text to clipboard
-    clipboardy.writeSync(text.text_segments.join("\n"));
+    clipboardy.writeSync(text.text_segments.join('\n'))
 } catch (e) {
-    console.error("Error occurred:");
-    console.error(e);
-    await sleep(30000);
+    console.error('Error occurred:')
+    console.error(e)
+    await sleep(30000)
 }

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,4 +1,4 @@
-export const LENS_ENDPOINT = 'https://lens.google.com/v3/upload'
+export const LENS_ENDPOINT = 'https://lens.google.com/v3/upload';
 
 // ico, bmp, jfif, pjpeg, jpeg, pjp, jpg, png, tif, tiff, webp, heic
 export const SUPPORTED_MIMES = [
@@ -9,7 +9,7 @@ export const SUPPORTED_MIMES = [
     'image/tiff',
     'image/webp',
     'image/heic'
-]
+];
 
 export const MIME_TO_EXT = {
     'image/x-icon': 'ico',
@@ -19,4 +19,4 @@ export const MIME_TO_EXT = {
     'image/tiff': 'tiff',
     'image/webp': 'webp',
     'image/heic': 'heic'
-}
+};

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,4 +1,4 @@
-export const LENS_ENDPOINT = 'https://lens.google.com/v3/upload';
+export const LENS_ENDPOINT = 'https://lens.google.com/v3/upload'
 
 // ico, bmp, jfif, pjpeg, jpeg, pjp, jpg, png, tif, tiff, webp, heic
 export const SUPPORTED_MIMES = [

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,280 @@
+import { imageDimensionsFromData } from 'image-dimensions'
+import setCookie from 'set-cookie-parser'
+
+import { LENS_ENDPOINT, MIME_TO_EXT, SUPPORTED_MIMES } from './consts.js'
+import { parseCookies, sleep } from './utils.js'
+
+export default class LensCore {
+    #config = {}
+    cookies = {}
+    _fetch = globalThis.fetch && globalThis.fetch.bind(globalThis)
+
+    constructor (config = {}, fetch) {
+        if (typeof config !== 'object') {
+            console.warn('Lens constructor expects an object, got', typeof config)
+            config = {}
+        }
+
+        if (fetch) this._fetch = fetch
+
+        const chromeVersion = config?.chromeVersion ?? '121.0.6167.140'
+        const majorChromeVersion = config?.chromeVersion?.split('.')[0] ?? chromeVersion.split('.')[0]
+
+        this.#config = {
+            chromeVersion,
+            majorChromeVersion,
+            sbisrc: `Google Chrome ${chromeVersion} (Official) Windows`,
+            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+            endpoint: LENS_ENDPOINT,
+            viewport: [1920, 1080],
+            headers: {},
+            ...config
+        }
+
+        // lowercase all headers
+        for (const key in this.#config.headers) {
+            const value = this.#config.headers[key]
+            if (!value) {
+                delete this.#config.headers[key]
+                continue
+            }
+            if (key.toLowerCase() !== key) {
+                delete this.#config.headers[key]
+                this.#config.headers[key.toLowerCase()] = value
+            }
+        }
+
+        this.#parseCookies()
+    }
+
+    #parseCookies () {
+        if (this.#config?.headers?.cookie) {
+            if (typeof this.#config?.headers?.cookie === 'string') {
+                // parse cookies from string
+                const cookies = parseCookies(this.#config.headers.cookie)
+                for (const cookie in cookies) {
+                    this.cookies[cookie] = {
+                        name: cookie,
+                        value: cookies[cookie],
+                        expires: Infinity
+                    }
+                }
+            } else {
+                this.cookies = this.#config.headers.cookie
+            }
+        }
+    }
+
+    updateOptions (options) {
+        for (const key in options) {
+            this.#config[key] = options[key]
+        }
+
+        this.#parseCookies()
+    }
+
+    async fetch (formdata, secondTry = false) {
+        const params = new URLSearchParams()
+
+        params.append('s', '' + 4) // SurfaceProtoValue - Surface.CHROMIUM
+        params.append('re', 'df') // RenderingEnvironment - DesktopWebFullscreen
+        params.append('stcs', '' + Date.now()) // timestamp
+        params.append('vpw', this.#config.viewport[0]) // viewport width
+        params.append('vph', this.#config.viewport[1]) // viewport height
+        params.append('ep', 'subb') // EntryPoint
+
+        const url = `${this.#config.endpoint}?${params.toString()}`
+        const headers = this.#generateHeaders()
+
+        for (const key in this.#config.headers) {
+            headers[key] = this.#config.headers[key]
+        }
+
+        this.#generateCookieHeader(headers)
+
+        const response = await this._fetch(url, {
+            method: 'POST',
+            headers,
+            body: formdata,
+            dispatcher: this.#config.dispatcher,
+            agent: this.#config.agent,
+            redirect: 'manual'
+        })
+
+        const text = await response.text()
+
+        this.#setCookies(response.headers.get('set-cookie'))
+
+        // in some of the EU countries, Google requires cookie consent
+        if (response.status === 302) {
+            if (secondTry) {
+                throw new LensError('Lens returned a 302 status code twice', response.status, response.headers, text)
+            }
+
+            const consentHeaders = this.#generateHeaders()
+            consentHeaders['Content-Type'] = 'application/x-www-form-urlencoded'
+            consentHeaders.Referer = 'https://consent.google.com/'
+            consentHeaders.Origin = 'https://consent.google.com'
+
+            this.#generateCookieHeader(consentHeaders)
+
+            const location = response.headers.get('Location')
+
+            if (!location) throw new Error('Location header not found')
+
+            const redirectLink = new URL(location)
+            const params = redirectLink.searchParams
+            params.append('x', '6')
+            params.append('set_eom', 'true')
+            params.append('bl', 'boq_identityfrontenduiserver_20240129.02_p0')
+            params.append('app', '0')
+
+            await sleep(500) // to not be suspicious
+            const saveConsentRequest = await fetch('https://consent.google.com/save', {
+                method: 'POST',
+                headers: consentHeaders,
+                body: params.toString(),
+                redirect: 'manual'
+            })
+
+            if (saveConsentRequest.status === 303) {
+                // consent was saved, save new cookies and retry the request
+                this.#setCookies(saveConsentRequest.headers.get('set-cookie'))
+                await sleep(500)
+                return this.fetch(formdata, true)
+            }
+        }
+
+        if (response.status !== 200) {
+            throw new LensError('Lens returned a non-200 status code', response.status, response.headers, text)
+        }
+
+        try {
+            const afData = this.getAFData(text)
+            return this.getFullText(afData)
+        } catch (e) {
+            throw new LensError('Could not parse response', response.status, response.headers, text)
+        }
+    }
+
+    #generateHeaders () {
+        return {
+            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Cache-Control': 'max-age=0',
+            Origin: 'https://lens.google.com',
+            Referer: 'https://lens.google.com/',
+            'Sec-Ch-Ua': `"Not A(Brand";v="99", "Google Chrome";v="${this.#config.majorChromeVersion}", "Chromium";v="${this.#config.majorChromeVersion}"`,
+            'Sec-Ch-Ua-Arch': '"x86"',
+            'Sec-Ch-Ua-Bitness': '"64"',
+            'Sec-Ch-Ua-Full-Version': `"${this.#config.chromeVersion}"`,
+            'Sec-Ch-Ua-Full-Version-List': `"Not A(Brand";v="99.0.0.0", "Google Chrome";v="${this.#config.majorChromeVersion}", "Chromium";v="${this.#config.majorChromeVersion}"`,
+            'Sec-Ch-Ua-Mobile': '?0',
+            'Sec-Ch-Ua-Model': '""',
+            'Sec-Ch-Ua-Platform': '"Windows"',
+            'Sec-Ch-Ua-Platform-Version': '"15.0.0"',
+            'Sec-Ch-Ua-Wow64': '?0',
+            'Sec-Fetch-Dest': 'document',
+            'Sec-Fetch-Mode': 'navigate',
+            'Sec-Fetch-Site': 'same-origin',
+            'Sec-Fetch-User': '?1',
+            'Upgrade-Insecure-Requests': '1',
+            'User-Agent': this.#config.userAgent,
+            'X-Client-Data': 'CIW2yQEIorbJAQipncoBCIH+ygEIlqHLAQjtocsBCPWYzQEIhaDNAQjd7M0BCMruzQEIg/DNAQjW8c0BCIDyzQEIz/TNAQiQ9c0BCLb3zQEYp+rNARib+M0BGMr4zQE='
+            /*
+                X-Client-Data: CIW2yQEIorbJAQipncoBCIH+ygEIlqHLAQjtocsBCPWYzQEIhaDNAQjd7M0BCMruzQEIg/DNAQjW8c0BCIDyzQEIz/TNAQiQ9c0BCLb3zQEYp+rNARib+M0BGMr4zQE=
+                Decoded:
+                message ClientVariations {
+                    // Active client experiment variation IDs.
+                    repeated int32 variation_id = [3300101, 3300130, 3313321, 3325697, 3330198, 3330285, 3361909, 3362821, 3372637, 3372874, 3373059, 3373270, 3373312, 3373647, 3373712, 3374006];
+                    // Active client experiment variation IDs that trigger server-side behavior.
+                    repeated int32 trigger_variation_id = [3372327, 3374107, 3374154];
+                }
+            */
+        }
+    }
+
+    #generateCookieHeader (header) {
+        if (Object.keys(this.cookies).length > 0) {
+            this.cookies = Object.fromEntries(Object.entries(this.cookies).filter(([name, cookie]) => cookie.expires > Date.now()))
+            header.cookie = Object.entries(this.cookies)
+                .map(([name, cookie]) => `${name}=${cookie.value}`).join('; ')
+        }
+    }
+
+    #setCookies (combinedCookieHeader) {
+        const splitCookieHeaders = setCookie.splitCookiesString(combinedCookieHeader)
+        const cookies = setCookie.parse(splitCookieHeaders)
+
+        if (cookies.length > 0) {
+            for (const cookie of cookies) {
+                this.cookies[cookie.name] = cookie
+                cookie.expires = cookie.expires.getTime()
+            }
+        }
+    }
+
+    getAFData (text) {
+        const callbacks = text.match(/AF_initDataCallback\((\{.*?\})\)/gms)
+        const lensCallback = callbacks.find(c => c.includes('DetectedObject'))
+
+        if (!lensCallback) {
+            console.log(callbacks)
+            throw new Error('Could not find matching AF_initDataCallback')
+        }
+
+        const match = lensCallback.match(/AF_initDataCallback\((\{.*?\})\)/ms)
+
+        return eval(`(${match[1]})`)
+    }
+
+    getFullText (afData) {
+        const data = afData.data
+        const fullTextPart = data[3]
+
+        return {
+            language: fullTextPart[3],
+            text_segments: fullTextPart[4][0][0]
+        }
+    }
+
+    async scanByData (uint8, fileName, mime) {
+        if (!SUPPORTED_MIMES.includes(mime)) {
+            throw new Error('File type not supported')
+        }
+
+        if (!fileName) fileName = `image.${MIME_TO_EXT[mime]}`
+
+        const dimensions = imageDimensionsFromData(uint8)
+        if (!dimensions) {
+            throw new Error('Could not determine image dimensions')
+        }
+
+        const { width, height } = dimensions
+        // Google Lens does not accept images larger than 1000x1000
+        if (width > 1000 || height > 1000) {
+            throw new Error('Image dimensions are larger than 1000x1000')
+        }
+
+        const file = new File([uint8], fileName, { type: mime })
+        const formdata = new FormData()
+
+        formdata.append('encoded_image', file)
+        formdata.append('original_width', '' + width)
+        formdata.append('original_height', '' + height)
+        formdata.append('processed_image_dimensions', `${width},${height}`)
+
+        return this.fetch(formdata)
+    }
+}
+
+export class LensError extends Error {
+    constructor (message, code, headers, body) {
+        super(message)
+        this.name = 'LensError'
+        this.code = code
+        this.headers = headers
+        this.body = body
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,304 +1,60 @@
-import fs from 'fs';
-import { fileTypeFromBuffer } from 'file-type';
-import { imageDimensionsFromData } from 'image-dimensions';
-import sharp from 'sharp';
-import { fetch } from 'undici';
-import setCookie from 'set-cookie-parser';
+import { readFile } from 'node:fs/promises'
+import { fileTypeFromBuffer } from 'file-type'
+import { imageDimensionsFromData } from 'image-dimensions'
+import sharp from 'sharp'
+import fetch from 'cross-fetch-ponyfill'
 
-import { LENS_ENDPOINT, MIME_TO_EXT, SUPPORTED_MIMES } from './consts.js';
-import { setDefault, parseCookies, sleep } from './utils.js';
+import LensCore from './core.js'
 
-export class LensError extends Error {
-    constructor(message, code, headers, body) {
-        super(message);
-        this.name = 'LensError';
-        this.code = code;
-        this.headers = headers;
-        this.body = body;
-    }
-}
-
-export default class Lens {
-    #config = {};
-    cookies = {};
-
-    constructor(config = {}) {
-        if(typeof config !== 'object') {
-            console.warn('Lens constructor expects an object, got', typeof config);
-            config = {};
+export default class Lens extends LensCore {
+    constructor (config = {}) {
+        if (typeof config !== 'object') {
+            console.warn('Lens constructor expects an object, got', typeof config)
+            config = {}
         }
-
-        const chromeVersion = config?.chromeVersion ?? '121.0.6167.140';
-        const majorChromeVersion = config?.chromeVersion?.split('.')[0] ?? chromeVersion.split('.')[0];
-
-        setDefault(config, 'chromeVersion', chromeVersion);
-        setDefault(config, 'majorChromeVersion', majorChromeVersion);
-        setDefault(config, 'sbisrc', `Google Chrome ${chromeVersion} (Official) Windows`);
-        setDefault(config, 'userAgent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36');
-        setDefault(config, 'endpoint', LENS_ENDPOINT);
-        setDefault(config, 'viewport', [1920, 1080]); // [width, height]
-        setDefault(config, 'headers', {});
-
-        // lowercase all headers
-        for(const key in config.headers) {
-            const value = config.headers[key];
-            if(!value) {
-                delete config.headers[key];
-                continue;
-            }
-            if(key.toLowerCase() !== key) {
-                delete config.headers[key];
-                config.headers[key.toLowerCase()] = value;
-            }
-        }
-
-        this.#config = config;
-
-        this.#parseCookies();
+        super(config, fetch)
     }
 
-    #parseCookies() {
-        if(this.#config?.headers?.cookie) {
-            if(typeof this.#config?.headers?.cookie === 'string') {
-                // parse cookies from string
-                const cookies = parseCookies(this.#config.headers.cookie);
-                for(const cookie in cookies) {
-                    this.cookies[cookie] = {
-                        name: cookie,
-                        value: cookies[cookie],
-                        expires: Infinity
-                    }
-                }
-            } else {
-                this.cookies = this.#config.headers.cookie;
-            }
-        }
+    async scanByFile (path) {
+        const file = await readFile(path)
+
+        return this.scanByBuffer(file, path.split('/').pop())
     }
 
-    updateOptions(options) {
-        for(const key in options) {
-            this.#config[key] = options[key];
-        }
+    async scanByBuffer (buffer, fileName) {
+        const fileType = await fileTypeFromBuffer(buffer)
 
-        this.#parseCookies();
-    }
+        if (!fileType) throw new Error('File type not supported')
 
-    async fetch(formdata, secondTry = false) {
-        const params = new URLSearchParams();
-
-        params.append('s', 4); // SurfaceProtoValue - Surface.CHROMIUM
-        params.append('re', 'df'); // RenderingEnvironment - DesktopWebFullscreen
-        params.append('stcs', Date.now()); // timestamp
-        params.append('vpw', this.#config.viewport[0]); // viewport width
-        params.append('vph', this.#config.viewport[1]); // viewport height
-        params.append('ep', 'subb'); // EntryPoint
-
-        const url = `${this.#config.endpoint}?${params.toString()}`;
-        const headers = this.#generateHeaders();
-
-        for(const key in this.#config.headers) {
-            headers[key] = this.#config.headers[key];
-        }
-
-        this.#generateCookieHeader(headers);
-        
-        let response = await fetch(url, {
-            method: 'POST',
-            headers,
-            body: formdata,
-            dispatcher: this.#config.dispatcher,
-            redirect: 'manual'
-        });
-
-        let text = await response.text();
-
-        this.#setCookies(response.headers.get('set-cookie'));
-
-        // in some of the EU countries, Google requires cookie consent
-        if(response.status === 302) {
-            if(secondTry) {
-                throw new LensError('Lens returned a 302 status code twice', response.status, response.headers, text);
-            }
-
-            const consentHeaders = this.#generateHeaders();
-            consentHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
-            consentHeaders['Referer'] = 'https://consent.google.com/';
-            consentHeaders['Origin'] = 'https://consent.google.com';
-
-            this.#generateCookieHeader(consentHeaders);
-
-            const redirectLink = new URL(response.headers.get('Location'));
-            const params = redirectLink.searchParams;
-            params.append('x', '6');
-            params.append('set_eom', 'true');
-            params.append('bl', 'boq_identityfrontenduiserver_20240129.02_p0');
-            params.append('app', '0');
-
-            await sleep(500); // to not be suspicious
-            const saveConsentRequest = await fetch('https://consent.google.com/save', {
-                method: 'POST',
-                headers: consentHeaders,
-                body: params.toString(),
-                redirect: 'manual'
-            });
-
-            if(saveConsentRequest.status === 303) {
-                // consent was saved, save new cookies and retry the request
-                this.#setCookies(saveConsentRequest.headers.get('set-cookie'));
-                await sleep(500);
-                return this.fetch(formdata, true);
-            }
-        }
-
-        if(response.status !== 200) {
-            throw new LensError('Lens returned a non-200 status code', response.status, response.headers, text);
-        }
-
-        try {
-            const af_data = this.getAFData(text);
-            const full_text = this.getFullText(af_data);
-
-            return full_text;
-        } catch(e) {
-            throw new LensError('Could not parse response', response.status, response.headers, text);
-        }
-    }
-
-    #generateHeaders() {
-        return {
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Cache-Control': 'max-age=0',
-            'Origin': 'https://lens.google.com',
-            'Referer': 'https://lens.google.com/',
-            'Sec-Ch-Ua': `"Not A(Brand";v="99", "Google Chrome";v="${this.#config.majorChromeVersion}", "Chromium";v="${this.#config.majorChromeVersion}"`,
-            'Sec-Ch-Ua-Arch': '"x86"',
-            'Sec-Ch-Ua-Bitness': '"64"',
-            'Sec-Ch-Ua-Full-Version': `"${this.#config.chromeVersion}"`,
-            'Sec-Ch-Ua-Full-Version-List': `"Not A(Brand";v="99.0.0.0", "Google Chrome";v="${this.#config.majorChromeVersion}", "Chromium";v="${this.#config.majorChromeVersion}"`,
-            'Sec-Ch-Ua-Mobile': '?0',
-            'Sec-Ch-Ua-Model': '""',
-            'Sec-Ch-Ua-Platform': '"Windows"',
-            'Sec-Ch-Ua-Platform-Version': '"15.0.0"',
-            'Sec-Ch-Ua-Wow64': '?0',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'same-origin',
-            'Sec-Fetch-User': '?1',
-            'Upgrade-Insecure-Requests': '1',
-            'User-Agent': this.#config.userAgent,
-            'X-Client-Data': 'CIW2yQEIorbJAQipncoBCIH+ygEIlqHLAQjtocsBCPWYzQEIhaDNAQjd7M0BCMruzQEIg/DNAQjW8c0BCIDyzQEIz/TNAQiQ9c0BCLb3zQEYp+rNARib+M0BGMr4zQE='
-            /*
-                X-Client-Data: CIW2yQEIorbJAQipncoBCIH+ygEIlqHLAQjtocsBCPWYzQEIhaDNAQjd7M0BCMruzQEIg/DNAQjW8c0BCIDyzQEIz/TNAQiQ9c0BCLb3zQEYp+rNARib+M0BGMr4zQE=
-                Decoded:
-                message ClientVariations {
-                    // Active client experiment variation IDs.
-                    repeated int32 variation_id = [3300101, 3300130, 3313321, 3325697, 3330198, 3330285, 3361909, 3362821, 3372637, 3372874, 3373059, 3373270, 3373312, 3373647, 3373712, 3374006];
-                    // Active client experiment variation IDs that trigger server-side behavior.
-                    repeated int32 trigger_variation_id = [3372327, 3374107, 3374154];
-                }
-            */
-        }
-    }
-
-    #generateCookieHeader(header_obj) {
-        if(Object.keys(this.cookies).length > 0) {
-            this.cookies = Object.fromEntries(Object.entries(this.cookies).filter(([name, cookie]) => cookie.expires > Date.now()));
-            header_obj['cookie'] = Object.entries(this.cookies)
-                .map(([name, cookie]) => `${name}=${cookie.value}`).join('; ');
-        }
-    }
-
-    #setCookies(combinedCookieHeader) {
-        const splitCookieHeaders = setCookie.splitCookiesString(combinedCookieHeader)
-        const cookies = setCookie.parse(splitCookieHeaders);
-
-        if(cookies.length > 0) {
-            for(const cookie of cookies) {
-                this.cookies[cookie.name] = cookie;
-                cookie.expires = cookie.expires.getTime();
-            }
-        }
-    }
-
-    getAFData(text) {
-        const callbacks = text.match(/AF_initDataCallback\((\{.*?\})\)/gms);
-        const lens_callback = callbacks.find(c => c.includes('DetectedObject'));
-
-        if(!lens_callback) {
-            console.log(callbacks);
-            throw new Error('Could not find matching AF_initDataCallback');
-        }
-
-        const match = lens_callback.match(/AF_initDataCallback\((\{.*?\})\)/ms);
-
-        return eval(`(${match[1]})`);
-    }
-    getFullText(af_data) {
-        const data = af_data.data;
-        const full_text_part = data[3];
-
-        return {
-            language: full_text_part[3],
-            text_segments: full_text_part[4][0][0]
-        };
-    }
-
-    async scanByFile(path) {
-        const file = await fs.promises.readFile(path);
-        
-        return this.scanByBuffer(file, path.split('/').pop());
-    }
-
-    async scanByBuffer(buffer, file_name) {
-        const fileType = await fileTypeFromBuffer(buffer);
-
-        if (!fileType || !SUPPORTED_MIMES.includes(fileType.mime)) {
-            throw new Error('File type not supported');
-        }
-
-        if(!file_name) {
-            const ext = MIME_TO_EXT[fileType.mime];
-            file_name = `image.${ext}`;
-        }
-
-        const dimensions = imageDimensionsFromData(Uint8Array.from(buffer));
-        if(!dimensions) {
-            throw new Error('Could not determine image dimensions');
+        const dimensions = imageDimensionsFromData(Uint8Array.from(buffer))
+        if (!dimensions) {
+            throw new Error('Could not determine image dimensions')
         }
 
         // Google Lens does not accept images larger than 1000x1000
-        if(dimensions.width > 1000 || dimensions.height > 1000) {
+        if (dimensions.width > 1000 || dimensions.height > 1000) {
             buffer = await sharp(buffer)
-                .resize(1000, 1000, { fit: "inside" })
+                .resize(1000, 1000, { fit: 'inside' })
                 .withMetadata()
                 .jpeg({ quality: 90, progressive: true })
-                .toBuffer();
-            
-            let newDimensions = imageDimensionsFromData(Uint8Array.from(buffer));
-            if(!newDimensions) {
-                throw new Error('Could not determine new image dimensions');
+                .toBuffer()
+
+            const newDimensions = imageDimensionsFromData(Uint8Array.from(buffer))
+            if (!newDimensions) {
+                throw new Error('Could not determine new image dimensions')
             }
 
-            dimensions.width = newDimensions.width;
-            dimensions.height = newDimensions.height;
+            dimensions.width = newDimensions.width
+            dimensions.height = newDimensions.height
         }
 
-        const file = new File([buffer], file_name, { type: fileType.mime });
-        const formdata = new FormData();
-
-        formdata.append('encoded_image', file);
-        formdata.append('original_width', dimensions.width);
-        formdata.append('original_height', dimensions.height);
-        formdata.append('processed_image_dimensions', `${dimensions.width},${dimensions.height}`);
-
-        return this.fetch(formdata);
+        return this.scanByData(buffer, fileName, fileType.mime)
     }
-    async scanByURL(url) {
-        const response = await fetch(url);
-        const buffer = await response.arrayBuffer();
 
-        return this.scanByBuffer(Buffer.from(buffer), url.split('/').pop());
+    async scanByURL (url) {
+        const response = await fetch(url)
+        const buffer = await response.arrayBuffer()
+
+        return this.scanByBuffer(Buffer.from(buffer), url.split('/').pop())
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { fileTypeFromBuffer } from 'file-type'
 import { imageDimensionsFromData } from 'image-dimensions'
 import sharp from 'sharp'
-import fetch from 'cross-fetch-ponyfill'
+import { fetch } from 'undici'
 
 import LensCore from './core.js'
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,34 @@
-import { readFile } from 'node:fs/promises'
-import { fileTypeFromBuffer } from 'file-type'
-import { imageDimensionsFromData } from 'image-dimensions'
-import sharp from 'sharp'
-import { fetch } from 'undici'
+import { readFile } from 'node:fs/promises';
+import { fileTypeFromBuffer } from 'file-type';
+import { imageDimensionsFromData } from 'image-dimensions';
+import sharp from 'sharp';
+import { fetch } from 'undici';
 
-import LensCore from './core.js'
+import LensCore from './core.js';
 
 export default class Lens extends LensCore {
     constructor (config = {}) {
         if (typeof config !== 'object') {
-            console.warn('Lens constructor expects an object, got', typeof config)
-            config = {}
+            console.warn('Lens constructor expects an object, got', typeof config);
+            config = {};
         }
-        super(config, fetch)
+        super(config, fetch);
     }
 
     async scanByFile (path) {
-        const file = await readFile(path)
+        const file = await readFile(path);
 
-        return this.scanByBuffer(file, path.split('/').pop())
+        return this.scanByBuffer(file, path.split('/').pop());
     }
 
     async scanByBuffer (buffer, fileName) {
-        const fileType = await fileTypeFromBuffer(buffer)
+        const fileType = await fileTypeFromBuffer(buffer);
 
-        if (!fileType) throw new Error('File type not supported')
+        if (!fileType) throw new Error('File type not supported');
 
-        const dimensions = imageDimensionsFromData(Uint8Array.from(buffer))
+        const dimensions = imageDimensionsFromData(Uint8Array.from(buffer));
         if (!dimensions) {
-            throw new Error('Could not determine image dimensions')
+            throw new Error('Could not determine image dimensions');
         }
 
         // Google Lens does not accept images larger than 1000x1000
@@ -37,24 +37,24 @@ export default class Lens extends LensCore {
                 .resize(1000, 1000, { fit: 'inside' })
                 .withMetadata()
                 .jpeg({ quality: 90, progressive: true })
-                .toBuffer()
+                .toBuffer();
 
-            const newDimensions = imageDimensionsFromData(Uint8Array.from(buffer))
+            const newDimensions = imageDimensionsFromData(Uint8Array.from(buffer));
             if (!newDimensions) {
-                throw new Error('Could not determine new image dimensions')
+                throw new Error('Could not determine new image dimensions');
             }
 
-            dimensions.width = newDimensions.width
-            dimensions.height = newDimensions.height
+            dimensions.width = newDimensions.width;
+            dimensions.height = newDimensions.height;
         }
 
-        return this.scanByData(buffer, fileName, fileType.mime)
+        return this.scanByData(buffer, fileName, fileType.mime);
     }
 
     async scanByURL (url) {
-        const response = await fetch(url)
-        const buffer = await response.arrayBuffer()
+        const response = await fetch(url);
+        const buffer = await response.arrayBuffer();
 
-        return this.scanByBuffer(Buffer.from(buffer), url.split('/').pop())
+        return this.scanByBuffer(Buffer.from(buffer), url.split('/').pop());
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,11 @@
 export function parseCookies (cookies) {
     return cookies.split('; ').reduce((prev, current) => {
-        const [name, ...value] = current.split('=')
-        prev[name] = value.join('=')
-        return prev
-    }, {})
+        const [name, ...value] = current.split('=');
+        prev[name] = value.join('=');
+        return prev;
+    }, {});
 }
 
 export function sleep (ms) {
-    return new Promise(resolve => setTimeout(resolve, ms))
+    return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,11 @@
-export function setDefault (obj, key, value) {
-    if(!obj[key]) {
-        obj[key] = value;
-    }
+export function parseCookies (cookies) {
+    return cookies.split('; ').reduce((prev, current) => {
+        const [name, ...value] = current.split('=')
+        prev[name] = value.join('=')
+        return prev
+    }, {})
 }
 
-export function parseCookies(cookies) {
-	return cookies.split('; ').reduce((prev, current) => {
-		const [name, ...value] = current.split('=');
-		prev[name] = value.join('=');
-		return prev;
-	}, {});
-}
-
-export function sleep(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms));
+export function sleep (ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
this PR adds support for non-nodeJS environments by removing the explicit undici and fs requirements, the reasoning behind it:
- fetch is globally available in nodeJS, and explicitly importing it covers a very minor range of non-supported minor node versions
- using global fetch allows the user to polyfill it themselves using `node-fetch` allowing the library to run on versions prior to node16, down to node12, example:
```js
import _fetch, {
  Blob as _Blob,
  File as _File,
  FormData as _FormData,
  Headers as _Headers,
  Request as _Request,
  Response as _Response
} from 'node-fetch'

global.fetch = global.fetch || _fetch

global.Blob = global.Blob || _Blob
global.File = global.File || _File
global.FormData = global.FormData || _FormData
global.Headers = global.Headers || _Headers
global.Request = global.Request || _Request
global.Response = global.Response || _Response
```

I also removed the "load by file" functionality, it seems mostly useless, as it's 1 line of code which is easy to write for any developer, and it strictly only allows the module to run on node, removing this allows the module to potentially run in other JS engines than node which implement fetch

Also removed sharp for the same reason, up to the user to crop the image.